### PR TITLE
Link examples to directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Welcome to the Brand SDK Apps Code Samples repository! Here, you'll find a serie
 
 ## What You'll Find Here
 
--   **Hello World App**: A basic introduction to our SDK. This app is pre-configured with our platform fonts, design system components, and styles.
--   **Secure Third-Party Request**: A sample app that demonstrates how to securely request third-party services using our SDK.
--   **App with user state example**: A sample app that demonstrates how to use the userState.
+-   [**Hello World App**](./examples/hello-world): A basic introduction to our SDK. This app is pre-configured with our platform fonts, design system components, and styles.
+-   [**Secure Third-Party Request**](./examples/secure-third-party-request): A sample app that demonstrates how to securely request third-party services using our SDK.
+-   [**App with user state example**](./examples/app-with-state): A sample app that demonstrates how to use the userState.
 
 Each example is accompanied by detailed documentation and comments within the code to help you understand how to utilize our SDK effectively. Whether you're just getting started or looking to implement specific features, these samples will guide you through the process.
 


### PR DESCRIPTION
We should link the examples on the main README.md for easier navigation.
